### PR TITLE
Update sync_remote.sh

### DIFF
--- a/sync_remote.sh
+++ b/sync_remote.sh
@@ -2,12 +2,16 @@
 
 # Idea: https://www.w3docs.com/snippets/git/how-to-fetch-all-git-branches.html
 
-git fetch --prune --all
+git fetch --prune --all 
 
 git branch -r |\
     grep -v '\->' |\
     while read remote; do
-        git branch --track "${remote#origin/}" "$remote";
+        if [[ -z $(git branch --list ${remote#origin/}) ]]; then
+            git branch --track "${remote#origin/}" "$remote"
+        else
+            echo "Notice: Branch named '${remote#origin/}' already exists."
+        fi
     done
 
 git pull --all


### PR DESCRIPTION
If the tracking branch already exists, do not do git-branch step, but just display a notice, else git-branch throws a fatal error for the existing branch.